### PR TITLE
Please add 'Philippe Castonguay' on about page

### DIFF
--- a/community/List-of-Projects-Using-0x-Protocol.md
+++ b/community/List-of-Projects-Using-0x-Protocol.md
@@ -38,4 +38,4 @@ These lists are composed of projects that publicly announced their interest in u
 + [0x Remote Hr](http://0x.remote.hr)
 + [0x Trade Viewer](http://0xtrades.info)
 + [0x Tracker](http://0xtracker.com)
-
+  


### PR DESCRIPTION
I'm sorry I can't find 'about' page github so I pull request on here
I think 'Philippe Castonguay' should add on 

https://0xproject.com/about
https://blog.0xproject.com/about

He deserve it much!