### PR TITLE
Use `stable` tag for `parity/parity` Docker image

### DIFF
--- a/0x.js/How-To-Deploy-A-Parity-Node.md
+++ b/0x.js/How-To-Deploy-A-Parity-Node.md
@@ -51,7 +51,7 @@ docker run -d \
 --log-opt max-file=20 \
 --name parity-kovan \
 -v /home/ubuntu/parity-data:/mnt \
- parity/parity \
+ parity/parity:stable \
 --testnet \
 --jsonrpc-interface 0.0.0.0 \
 --rpccorsdomain '*' \


### PR DESCRIPTION
While working on macOS High Sierra with Docker Version 18.03.0-ce-mac60 (23751) installed, using the default `parity/parity:latest` image builds and runs the beta/edge release of Parity which has intermittent connectivity issues and some other quirks. Using the stable tag made all that go away. I wonder if it is worth recommending that folks use the stable tag of parity here ...