### PR TITLE
Added LedgerDex to relayer list

### DIFF
--- a/community/List-of-Projects-Using-0x-Protocol.md
+++ b/community/List-of-Projects-Using-0x-Protocol.md
@@ -29,6 +29,7 @@ These lists are composed of projects that publicly announced their interest in u
 * [Ethfinex](https://www.ethfinex.com/)
 * [IDT Exchange](https://www.idtexchange.com/)
 * [Instex](https://app.instex.io/)
+* [LedgerDex](https://www.ledgerdex.com/)
 * [MobiDex](http://mobidex.io)
 * [OpenRelay](https://openrelay.xyz)
 * [Paradex](https://paradex.io/)


### PR DESCRIPTION
As LedgerDex Beta is live on mainnet and testnets, I'm adding it to the relayer list.