### PR TITLE
Add Paradigm Protocol to the list of dApps using 0x

### DIFF
--- a/community/List-of-Projects-Using-0x-Protocol.md
+++ b/community/List-of-Projects-Using-0x-Protocol.md
@@ -17,6 +17,7 @@ These lists are composed of projects that publicly announced their interest in u
 * [Maker](https://makerdao.com/)
 * [MelonPort](https://melonport.com/)
 * [OpenANX](https://www.openanx.org/)
+* [Paradigm Protocol](https://paradigm.market/)
 * [Request Network](https://request.network/)
 * [Set](https://setprotocol.com/)
 


### PR DESCRIPTION
PR to add the Paradigm Protocol (https://paradigm.market/) to the list of projects using 0x.