### PR TITLE
Fix newlines

### DIFF
--- a/developer-tools/Web3-Provider-Explained.md
+++ b/developer-tools/Web3-Provider-Explained.md
@@ -1,8 +1,11 @@
 When instantiating a [new instance of the 0x.js library](https://0x.org/docs/0x.js#zeroEx), we require that you pass in a Web3 provider. This Web3 provider allows your application to communicate with an Ethereum Node. Since there doesn't seem to be great documentation on what exactly a Web3 Provider is, we thought we'd fill the gap.
 
+
 A provider can be any module or class instance that implements the `sendAsync` method (simply `send` in web3 V1.0 Beta). That's it. What this `sendAsync` method does is take JSON RPC payload requests and handles them. [Web3.js](https://github.com/ethereum/web3.js/) is an example of a javascript module that contains a Web3 HTTP Provider.
 
+
 Using a configured Web3 Provider, the application can request signatures, estimate gas and gas price, and submit transactions to an Ethereum node.
+
 
 The simplest example of a provider is:
 


### PR DESCRIPTION
Because now there is no space after dots and it looks like "Web3.js is an example of a javascript module that contains a Web3 HTTP Provider**.Using** a configured Web3 Provider, the application can request signatures, estimate gas and gas price, and submit transactions to an Ethereum node**.The** simplest example of a provider is:"