### PR TITLE
Update example relayer SRA links to be more obviously illustrative

### DIFF
--- a/instant/Get-Started-With-Instant.md
+++ b/instant/Get-Started-With-Instant.md
@@ -36,7 +36,7 @@ The 0x Instant UI and Asset Buyer are bundled together in a convenient JS packag
             function renderZeroExInstant() {
                 zeroExInstant.render(
                     {
-                        orderSource: 'https://api.relayer.com/sra/v2/',
+                        orderSource: 'https://example.donotusethis.com/sra/v2/',
                     },
                     'body',
                 );
@@ -94,7 +94,7 @@ Using [/asset_pairs](https://github.com/0xProject/standard-relayer-api/blob/mast
 ```javascript
 zeroExInstant.render(
     {
-        orderSource: 'https://api.relayer.com/sra/v2/',
+        orderSource: 'https://example.donotusethis.com/sra/v2/',
     },
     'body',
 );
@@ -107,7 +107,7 @@ This will give you more control over what provider is passed in and where RPC ca
 ```javascript
 zeroExInstant.render(
     {
-        orderSource: 'https://api.relayer.com/sra/v2/',
+        orderSource: 'https://example.donotusethis.com/sra/v2/',
         provider: window.ethereum,
         walletDisplayName: 'Trust Wallet',
     },
@@ -120,7 +120,7 @@ zeroExInstant.render(
 ```javascript
 zeroExInstant.render(
     {
-        orderSource: 'https://api.relayer.com/sra/v2/',
+        orderSource: 'https://example.donotusethis.com/sra/v2/',
         availableAssetDatas: ['0xf47261b04c32345ced77393b3530b1eed0f346429d'],
         defaultSelectedAssetData: '0xf47261b04c32345ced77393b3530b1eed0f346429d',
     },
@@ -135,7 +135,7 @@ zeroExInstant.render(
 ```javascript
 zeroExInstant.render(
     {
-        orderSource: 'https://api.relayer.com/sra/v2/',
+        orderSource: 'https://example.donotusethis.com/sra/v2/',
         affiliateInfo: {
             feeRecipient: '0x50ff5828a216170cf224389f1c5b0301a5d0a230',
             feePercentage: 0.03,
@@ -281,7 +281,7 @@ There are several static `AssetBuyer` factory methods that can be used to constr
 
 ```javascript
 const provider = window.ethereum;
-const sraUrl = 'https://api.relayer.com/sra/v2/';
+const sraUrl = 'https://example.donotusethis.com/sra/v2/';
 const zrxAssetData = '0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498';
 const assetBuyer = AssetBuyer.getAssetBuyerForStandardRelayerAPIUrl(provider, sraUrl);
 const amountToBuy = new BigNumber(10000000);

--- a/instant/Learn-About-Affiliate-Fees.md
+++ b/instant/Learn-About-Affiliate-Fees.md
@@ -13,7 +13,7 @@ Example: 3% of transaction volume (in ETH) will de deposited into 0x50ff5828a216
 ```javascript
 zeroExInstant.render(
     {
-        orderSource: 'https://api.relayer.com/sra/v2/',
+        orderSource: 'https://example.donotusethis.com/sra/v2/',
         affiliateInfo: {
             feeRecipient: '0x50ff5828a216170cf224389f1c5b0301a5d0a230',
             feePercentage: 0.03,

--- a/instant/Questions-About-Instant.md
+++ b/instant/Questions-About-Instant.md
@@ -26,7 +26,7 @@ See below for an example of how to check liquidity on Radar Relay for a given ER
     const erc20TokenAddress = '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07';
     const assetData = zeroExInstant.assetDataForERC20TokenAddress(erc20TokenAddress);
 
-    zeroExInstant.hasLiquidityForAssetDataAsync(assetData, 'https://api.relayer.com/sra/v2/').then(l => {
+    zeroExInstant.hasLiquidityForAssetDataAsync(assetData, 'https://example.donotusethis.com/sra/v2/').then(l => {
         document.getElementById('liquidityContainer').innerHTML = `Relayer has liquidity: ${l ? 'Yes' : 'No'}`;
     });
 </script>
@@ -130,7 +130,7 @@ For apps using React Native or apps that have a web view, the asset buyer engine
 
 #### Q: How can 0x be used to trade NFTs?
 
-The 0x Instant UI currently only supports trading of ERC20 tokens.  You can use [asset-buyer](https://0x.org/docs/asset-buyer#introduction), the library that powers Instant, to develop a custom interface that allow users to easily purchase NFTs with a single tap — no need to purchase wrap ETH or set an allowance!
+The 0x Instant UI currently only supports trading of ERC20 tokens. You can use [asset-buyer](https://0x.org/docs/asset-buyer#introduction), the library that powers Instant, to develop a custom interface that allow users to easily purchase NFTs with a single tap — no need to purchase wrap ETH or set an allowance!
 
 ### Affiliates
 


### PR DESCRIPTION
Developers are getting confused when the example api url doesn't work, should we just change them to all be radar relay's api url or change them into something more obvious like: `https://example.donotusethis.com/sra/v2/`