### PR TITLE
Update: Add Oc2 (Off Chain On Chain) to the list.

### DIFF
--- a/community/2-List-of-Projects-Using-0x-Protocol.md
+++ b/community/2-List-of-Projects-Using-0x-Protocol.md
@@ -38,6 +38,7 @@ These lists are composed of projects that publicly announced their interest in u
 * [Lake Project](https://lakeproject.co/)
 * [LedgerDex](https://www.ledgerdex.com/)
 * [MobiDex](https://mobidex.io)
+* [Oc2](https://oc2realm.com)
 * [OpenRelay](https://openrelay.xyz)
 * [Paradex](https://paradex.io/)
 * [Radar Relay](https://radarrelay.com/)


### PR DESCRIPTION
Adding Oc2 (Off Chain On Chain) to the list.