### PR TITLE
Update 4-How-To-Deploy-A-Parity-Node.md

### DIFF
--- a/developer-tools/4-How-To-Deploy-A-Parity-Node.md
+++ b/developer-tools/4-How-To-Deploy-A-Parity-Node.md
@@ -104,10 +104,8 @@ docker run -d \
 --jsonrpc-interface 0.0.0.0 \
 --jsonrpc-cors '*' \
 --jsonrpc-hosts all \
--d /mnt \
 --auto-update none \
 --no-download \
---tx-queue-gas off \
 --tx-queue-size 1000000
 ```
 


### PR DESCRIPTION
-d /mnt causes permissions errors and is erroneous.

--tx-queue-gas off \ comes up as an invalid parameter per parity.